### PR TITLE
Allow overriding `redirect_uri` entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ config.omniauth(
 * `name`: change endpoint to /auth/tiktok_another, /auth/tiktok_another/callback. default: `"tiktok_login"`
 * `skip_info`: skip User Info API call to retrieve `info` hash. default: `false`
 * `scope`: oauth scopes, seperated by comma. default: `"user.info.basic"`
+* `redirect_uri`: change the redirect_uri used after the user authenticates with TikTok (overrides the `name` option)
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ config.omniauth(
 
 ## Options
 
-* `name`: change endpoint to /auth/tiktok_another, /auth/tiktok_another/callback. default: `"tiktok_login"`
+* `name`: change endpoint to /auth/tiktok_another, /auth/tiktok_another/callback. default: `"tiktok-loginkit"`
 * `skip_info`: skip User Info API call to retrieve `info` hash. default: `false`
 * `scope`: oauth scopes, seperated by comma. default: `"user.info.basic"`
 * `redirect_uri`: change the redirect_uri used after the user authenticates with TikTok (overrides the `name` option)

--- a/lib/omniauth/strategies/tiktok_loginkit.rb
+++ b/lib/omniauth/strategies/tiktok_loginkit.rb
@@ -63,7 +63,7 @@ module OmniAuth
       end
 
       def callback_url
-        full_host + callback_path
+        options[:redirect_uri] || (full_host + callback_path)
       end
 
       private

--- a/spec/omniauth/strategies/tiktok_loginkit_spec.rb
+++ b/spec/omniauth/strategies/tiktok_loginkit_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe OmniAuth::Strategies::TiktokLoginkit do # rubocop:disable Metrics
   let(:app) { ->(_) { [200, {}, "success"] } }
   let(:client_key) { "CLIENT_KEY" }
   let(:client_secret) { "CLIENT_SECRET" }
-  let(:subject) { OmniAuth::Strategies::TiktokLoginkit.new(app, client_key, client_secret) }
+  let(:redirect_uri) { nil }
+  let(:subject) { OmniAuth::Strategies::TiktokLoginkit.new(app, client_key, client_secret, redirect_uri: redirect_uri) }
   let(:session) { {} }
 
   before do
@@ -22,6 +23,15 @@ RSpec.describe OmniAuth::Strategies::TiktokLoginkit do # rubocop:disable Metrics
       )
     end
 
+    context "callback_url" do
+      let(:redirect_uri) { "https://my-custom-redirect-uri.com/" }
+
+      it "uses the redirect_uri option if present" do
+        subject.call!(env)
+        expect(subject.callback_url).to eq(redirect_uri)
+      end
+    end
+
     it "redirects to the authorize_url" do
       status, headers, = subject.call!(env)
       expect(status).to eq(302)
@@ -31,7 +41,7 @@ RSpec.describe OmniAuth::Strategies::TiktokLoginkit do # rubocop:disable Metrics
       expect(redirected_uri.path).to eq("/v2/auth/authorize/")
       expect(redirected_params).to include(
         "client_key" => client_key,
-        "redirect_uri" => "http://localhost:3000/auth/tiktok-loginkit/callback",
+        "redirect_uri" => subject.callback_url,
         "response_type" => "code",
         "scope" => "user.info.basic",
         "state" => subject.session["omniauth.state"]


### PR DESCRIPTION
In some cases, we may need to override the entire `callback_url` used by the strategy. The option is named `redirect_uri` to match what the [TikTok Loginkit docs](https://developers.tiktok.com/doc/login-kit-web/) call it.